### PR TITLE
feat(test connection): add cluster to Epsagon only if it is configured ok

### DIFF
--- a/epsagon_kubernetes_subscription.sh
+++ b/epsagon_kubernetes_subscription.sh
@@ -36,7 +36,7 @@ function test_connection {
     DATA=$1
     SERVER=${2%,}
     echo "Testing Epsagon connection to server ${SERVER}..."
-    RESULT="$(curl -X POST https://api.epsagon.com/containers/k8s/test_cluster_connection -d $DATA -H 'Content-Type: application/json')"
+    RESULT="$(curl -X POST https://api.epsagon.com/containers/k8s/check_cluster_connection -d $DATA -H 'Content-Type: application/json')"
     #Expected Response format:
     # {{
     #   "connection_status": "successful" / "failed",

--- a/epsagon_kubernetes_subscription.sh
+++ b/epsagon_kubernetes_subscription.sh
@@ -41,20 +41,21 @@ function test_connection {
     #Expected Response format:
     # {
     #   "connection_status": "successful" / "failed",
-    #   "reason": "" # Optional, failure reason string, only relevant if "status"=="failed"
+    #   "connection_failure_reason": "" # Optional, failure reason string, only relevant if "status"=="failed"
     # }
     CONNECTION_STATUS=`echo $RESULT | grep -o -E "\"connection_status\": \"[^\"]+\"" | awk -F\: '{print $2}'`
+    CONNECTION_STATUS=`echo $CONNECTION_STATUS | xargs`
     if [ ! -z $CONNECTION_STATUS ]; then
-        ERROR=`echo $RESULT | grep -o -E "\"reason\": \".+\"" | awk '{print $2}'`
-        if [ -z "$ERROR" ]; then
+        if [ "$CONNECTION_STATUS" == "successful" ]; then
             echo "Succesfully connected to server ${SERVER}"
             return 0
         else
-            echo "Could not connect to server ${SERVER}, error message: ${ERROR}"
+            ERROR=`echo $RESULT | grep -o -E "\"connection_failure_reason\": \".+\"" | awk '{print $2}'`
+            echo "Integration failed, see https://docs.epsagon.com/docs/environments-kubernetes. Error message: ${ERROR}"
             return 1
         fi
     else
-        echo "Failed to test connection to server, please contact us"
+        echo "Connection to Epsagon failed, please see: https://docs.epsagon.com/docs/environments-kubernetes"
         return 1
     fi
 }


### PR DESCRIPTION
Example outputs:

Successful test:
```
Testing Epsagon connection to server <server_url>...
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  1187  100    35  100  1152     31   1051  0:00:01  0:00:01 --:--:--  1082
Succesfully connected to server <server_url>
Integrating cluster into epsagon...
```
Failure to connect to the cluster:
```
Testing Epsagon connection to server <server_url>...
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   404  100   199  100   205    307    316 --:--:-- --:--:-- --:--:--   623
Integration failed, see https://docs.epsagon.com/docs/environments-kubernetes. Error message: {\"kind\":\"Status\",\"apiVersion\":\"v1\",\"metadata\":{},\"status\":\"Failure\",\"message\":\"Unauthorized\",\"reason\":\"Unauthorized\",\"code\":401}\n"
```
Failure to test the connection (Epsagon internal server error):
```
Testing Epsagon connection to server https://api-epsagon-dev-k8s-local-1k8iem-204167116.eu-west-1.elb.amazonaws.com...
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  1183  100    31  100  1152     14    548  0:00:02  0:00:02 --:--:--   563
Connection to Epsagon failed, please see: https://docs.epsagon.com/docs/environments-kubernetes
```